### PR TITLE
Enhancement/no more sync problems because better documentation

### DIFF
--- a/example/viewer.py
+++ b/example/viewer.py
@@ -5,7 +5,8 @@ import cv2
 import numpy as np
 
 k4a = PyK4A(Config(color_resolution=ColorResolution.RES_720P,
-                   depth_mode=pyk4a.DepthMode.NFOV_UNBINNED, ))
+                   depth_mode=pyk4a.DepthMode.NFOV_UNBINNED,
+                   synchronized_images_only=True, ))
 k4a.connect()
 
 # getters and setters directly get and set on device
@@ -16,6 +17,7 @@ assert k4a.whitebalance == 4510
 
 while 1:
     img_color = k4a.get_capture(color_only=True)
+    # img_color, img_depth = k4a.get_capture()  # Would also fetch the depth image
     if np.any(img_color):
         cv2.imshow('k4a', img_color[:, :, :3])
         key = cv2.waitKey(10)

--- a/pyk4a/config.py
+++ b/pyk4a/config.py
@@ -61,7 +61,7 @@ class Config:
                  color_resolution=ColorResolution.RES_720P,
                  depth_mode=DepthMode.NFOV_UNBINNED,
                  camera_fps=FPS.FPS_30,
-                 synchronized_images_only=False,
+                 synchronized_images_only=True,
                  depth_delay_off_color_usec=0,
                  wired_sync_mode=WiredSyncMode.STANDALONE,
                  subordinate_delay_off_master_usec=0,

--- a/pyk4a/pyk4a.py
+++ b/pyk4a/pyk4a.py
@@ -210,16 +210,3 @@ class PyK4A:
             raise K4AException()
         elif res == Result.Timeout:
             raise K4ATimeoutException()
-
-
-if __name__ == "__main__":
-    k4a = PyK4A(Config())
-    k4a.connect()
-    print("Connected")
-    jack_in, jack_out = k4a.get_sync_jack()
-    print("Jack status : in -> {} , out -> {}".format(jack_in, jack_out))
-    for _ in range(10):
-        color, depth = k4a.device_get_capture(color_only=False)
-        print(color.shape, depth.shape)
-    k4a.disconnect()
-    print("Disconnected")

--- a/pyk4a/pyk4a.py
+++ b/pyk4a/pyk4a.py
@@ -169,7 +169,7 @@ class PyK4A:
         self._set_color_control(ColorControlCommand.EXPOSURE_TIME_ABSOLUTE, value=value, mode=mode)
 
     @whitebalance.setter
-    def whitebalance(self, value: int, mode=ColorControlMode.MANUAL):
+    def whitebalance(self, value: int):
         self._set_color_control(ColorControlCommand.WHITEBALANCE, value)
 
     @whitebalance_mode_auto.setter


### PR DESCRIPTION
Makes it clear that get_capture can sometimes return None if config argument sync_images is False.

Added documentation explaining how to use the get_capture function properly.

Typehinting required adding numpy import. This should benefit users using ide with typehint support.

Split in two subfunctions, _get_capture_color and _get_capture_depth, which allows cleaner typehinting. Using typing.Unions of typing.Unions would have been a mess.