### PR TITLE
Better multithreading performance

### DIFF
--- a/example/threads.py
+++ b/example/threads.py
@@ -1,0 +1,148 @@
+import threading
+from time import sleep
+from typing import Tuple, Optional, List, Dict
+from math import sin
+import numpy as np
+from pyk4a import PyK4A
+
+last_capture: Optional[Tuple[np.ndarray, np.ndarray]] = None
+
+
+class Worker(threading.Thread):
+    def __init__(self):
+        self._halt = False
+        self._count = 0
+        super().__init__()
+
+    def halt(self):
+        self._halt = True
+
+    @property
+    def count(self):
+        return self._count
+
+
+class CpuWorker(Worker):
+    def run(self) -> None:
+        while not self._halt:
+            sin(self._count)
+            self._count += 1
+
+
+class CameraWorker(Worker):
+    def __init__(self, device_id=0, thread_safe: bool = True):
+        self._device_id = device_id
+        self._thread_safe = thread_safe
+        super().__init__()
+
+    def run(self) -> None:
+        camera = PyK4A(device_id=self._device_id, thread_safe=self._thread_safe)
+        camera.connect()
+        while not self._halt:
+            camera.get_capture(transform_depth_to_color=True)
+            self._count += 1
+        sleep(0.1)
+        camera.disconnect()
+        del camera
+
+
+def bench(
+    camera_workers: List[CameraWorker], cpu_workers: List[CpuWorker], duration: float
+) -> int:
+    # start cameras
+    for camera_worker in camera_workers:
+        camera_worker.start()
+        while not camera_worker.count:
+            sleep(0.1)
+            if not camera_worker.is_alive():
+                print("Cannot start camera")
+                exit(1)
+    # start cpu-bound workers
+    for cpu_worker in cpu_workers:
+        cpu_worker.start()
+
+    sleep(duration)
+
+    for cpu_worker in cpu_workers:
+        cpu_worker.halt()
+    for camera_worker in camera_workers:
+        camera_worker.halt()
+
+    # wait while all workers stop
+    while True:
+        for worker in camera_workers + cpu_workers:
+            if worker.is_alive():
+                sleep(0.05)
+                break
+        else:
+            break
+    total = 0
+    for cpu_worker in cpu_workers:
+        total += cpu_worker.count
+    return total
+
+
+def draw(results: Dict[int, Dict[bool, int]]):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return
+    plt.figure()
+    plt.subplot(2, 1, 1)
+    plt.title("Threading performance")
+    plt.ylabel("Operations Count")
+    plt.xlabel("CPU Workers count")
+    plt.plot(
+        results.keys(),
+        [result[True] for result in results.values()],
+        "r",
+        label="Thread safe",
+    )
+    plt.plot(
+        results.keys(),
+        [result[False] for result in results.values()],
+        "g",
+        label="Non thread safe",
+    )
+    plt.legend()
+
+    plt.subplot(2, 1, 2)
+    plt.title("Difference")
+    plt.ylabel("Difference, %")
+    plt.xlabel("CPU Workers count")
+    plt.plot(
+        results.keys(),
+        [
+            float(result[False] - result[True]) / result[True] * 100
+            for result in results.values()
+        ],
+    )
+    xmin, xmax, ymin, ymax = plt.axis()
+    if ymin > 0:
+        ymin = 0
+        plt.axis([xmin, xmax, ymin, ymax])
+
+    plt.show()
+
+
+MAX_CPU_WORKERS_COUNT = 5
+DURATION = 10
+results: Dict[int, Dict[bool, int]] = {}
+for cpu_workers_count in range(1, MAX_CPU_WORKERS_COUNT + 1):
+    result: Dict[bool, int] = {}
+    for thread_safe in (True, False):
+        camera_workers = [CameraWorker(thread_safe=thread_safe)]
+        cpu_workers = [CpuWorker() for i in range(cpu_workers_count)]
+        operations = bench(
+            camera_workers=camera_workers, cpu_workers=cpu_workers, duration=DURATION
+        )
+        print(
+            f"Bench result: cpu_workers={cpu_workers_count}, thread_safe={thread_safe}, operations={operations}"
+        )
+        result[thread_safe] = operations
+
+    percent = float(result[False] - result[True]) / result[True] * 100
+    print(f"Difference: {percent: 0.2f} %")
+    results[cpu_workers_count] = result
+
+draw(results)

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -25,7 +25,6 @@ extern "C" {
     device_container devices[MAX_DEVICES];
 
     static PyThreadState* _gil_release(uint32_t device_id) {
-        return NULL;
         PyThreadState *thread_state = NULL;
         if (devices[device_id].thread_safe == 0) {
             thread_state = PyEval_SaveThread();

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -141,7 +141,10 @@ extern "C" {
             k4a_capture_release(devices[device_id].capture);
         }
         k4a_capture_create(&devices[device_id].capture);
-        k4a_wait_result_t result = k4a_device_get_capture(devices[device_id].device, &devices[device_id].capture, timeout);
+        k4a_wait_result_t result;
+        Py_BEGIN_ALLOW_THREADS
+        result = k4a_device_get_capture(devices[device_id].device, &devices[device_id].capture, timeout);
+        Py_END_ALLOW_THREADS
         return Py_BuildValue("I", result);
     }
 

--- a/pyk4a/pyk4a.py
+++ b/pyk4a/pyk4a.py
@@ -24,9 +24,10 @@ class K4ATimeoutException(K4AException):
 class PyK4A:
     TIMEOUT_WAIT_INFINITE = -1
 
-    def __init__(self, config=Config(), device_id=0):
+    def __init__(self, config=Config(), device_id=0, thread_safe: bool = True):
         self._device_id = device_id
         self._config = config
+        self._thread_safe = thread_safe
         self.is_running = False
 
     def __del__(self):
@@ -55,7 +56,8 @@ class PyK4A:
         self._verify_error(res)
 
     def _device_open(self):
-        res = k4a_module.device_open(self._device_id)
+        thread_safe = 1 if self._thread_safe else 0
+        res = k4a_module.device_open(self._device_id, thread_safe)
         self._verify_error(res)
 
     def _device_close(self):


### PR DESCRIPTION
if you read captures in threads app performance will be decreased due GIL locking.
This PR release GIL inside C functions if you use `thread_safe=False` mode.
In this case you can safety work with camera only from one thread.
