### PR TITLE
Allow install with pip --user --editable .

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@ import sys
 if sys.version_info[0] == 2:
     sys.exit("Python 2 is not supported.")
 
+# Enables --editable install with --user
+# https://github.com/pypa/pip/issues/7953
+import site
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
 # Bypass import numpy before running install_requires
 # https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy
 class get_numpy_include:


### PR DESCRIPTION
PEP517 implemented recently in pip does not allow editable install in user site-packages. This means I had to run `sudo make build` to install in editable mode.

See discussion here https://github.com/pypa/pip/issues/7953