### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Make sure you replace the paths in the following instructions with your own k4a 
 It is important to replace `1.2.0` with your installed version of the SDK.
 
 ```
-pip install pyk4a --global-option=build_ext --global-option="-IC:\Program Files\Azure Kinect SDK v1.2.0\sdk\include" --global-option="-LC:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\lib"
+pip install pyk4a --no-use-pep517 --global-option=build_ext --global-option="-IC:\Program Files\Azure Kinect SDK v1.4.1\sdk\include" --global-option="-LC:\Program Files\Azure Kinect SDK v1.4.1\sdk\windows-desktop\amd64\release\lib"
 ```
 
 Don't forget to add the folder containing the release `k4a.dll` to your Path env variable `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\bin`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
-build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
I cannot build module on windows via command from `README.md`:  like as `--global-option=...` not passed to `setup.py`.
But I can install module from source via `python setup.py build_ext  -I...`.
Option `--no-use-pep517` is easiest workaround. Let's fix README.

Maybe after #39 some additional fix will be required to build system. 