### PR TITLE
Added transform_depth_image_to_color_camera_custom functionality

### DIFF
--- a/example/viewer_transformation.py
+++ b/example/viewer_transformation.py
@@ -21,6 +21,8 @@ def main():
             cv2.imshow("Transformed Depth", colorize(capture.transformed_depth, (None, 5000)))
         if capture.transformed_color is not None:
             cv2.imshow("Transformed Color", capture.transformed_color)
+        if capture.transformed_ir is not None:
+            cv2.imshow("Transformed IR", colorize(capture.transformed_ir, (None, 500), colormap=cv2.COLORMAP_JET))
 
         key = cv2.waitKey(10)
         if key != -1:

--- a/pyk4a/__init__.py
+++ b/pyk4a/__init__.py
@@ -13,7 +13,12 @@ from .config import (
 from .errors import K4AException, K4ATimeoutException
 from .playback import PyK4APlayback, SeekOrigin
 from .pyk4a import ColorControlCapabilities, PyK4A
-from .transformation import color_image_to_depth_camera, depth_image_to_color_camera, depth_image_to_point_cloud
+from .transformation import (
+    color_image_to_depth_camera,
+    depth_image_to_color_camera,
+    depth_image_to_color_camera_custom,
+    depth_image_to_point_cloud,
+)
 
 
 __all__ = (
@@ -37,4 +42,5 @@ __all__ = (
     "color_image_to_depth_camera",
     "depth_image_to_point_cloud",
     "depth_image_to_color_camera",
+    "depth_image_to_color_camera_custom",
 )

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -6,7 +6,12 @@ import k4a_module
 
 from .calibration import Calibration
 from .config import ImageFormat
-from .transformation import color_image_to_depth_camera, depth_image_to_color_camera, depth_image_to_point_cloud
+from .transformation import (
+    color_image_to_depth_camera,
+    depth_image_to_color_camera,
+    depth_image_to_color_camera_custom,
+    depth_image_to_point_cloud,
+)
 
 
 class PyK4ACapture:
@@ -25,6 +30,7 @@ class PyK4ACapture:
         self._transformed_depth: Optional[np.ndarray] = None
         self._transformed_depth_point_cloud: Optional[np.ndarray] = None
         self._transformed_color: Optional[np.ndarray] = None
+        self._transformed_ir: Optional[np.ndarray] = None
 
     @property
     def color(self) -> Optional[np.ndarray]:
@@ -78,3 +84,11 @@ class PyK4ACapture:
                 self.color, self.depth, self._calibration, self.thread_safe
             )
         return self._transformed_color
+
+    @property
+    def transformed_ir(self) -> Optional[np.ndarray]:
+        if self._transformed_ir is None and self.ir is not None and self.depth is not None:
+            self._transformed_ir = depth_image_to_color_camera_custom(
+                self.depth, self.ir, self._calibration, self.thread_safe
+            )
+        return self._transformed_ir

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -88,7 +88,7 @@ class PyK4ACapture:
     @property
     def transformed_ir(self) -> Optional[np.ndarray]:
         if self._transformed_ir is None and self.ir is not None and self.depth is not None:
-            self._transformed_ir = depth_image_to_color_camera_custom(
+            self._transformed_ir, self._transformed_depth = depth_image_to_color_camera_custom(
                 self.depth, self.ir, self._calibration, self.thread_safe
             )
         return self._transformed_ir

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -88,7 +88,9 @@ class PyK4ACapture:
     @property
     def transformed_ir(self) -> Optional[np.ndarray]:
         if self._transformed_ir is None and self.ir is not None and self.depth is not None:
-            self._transformed_ir, self._transformed_depth = depth_image_to_color_camera_custom(
-                self.depth, self.ir, self._calibration, self.thread_safe
-            )
+            result = depth_image_to_color_camera_custom(self.depth, self.ir, self._calibration, self.thread_safe)
+            if result is None:
+                return None
+            else:
+                self._transformed_ir, self._transformed_depth = result
         return self._transformed_ir

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -467,6 +467,7 @@ extern "C" {
                 dims[2] = 1;
                 *img_dst = (PyArrayObject*) PyArray_SimpleNewFromData(3, dims, NPY_UINT8, buffer);
                 break;
+            case K4A_IMAGE_FORMAT_CUSTOM16:
             case K4A_IMAGE_FORMAT_DEPTH16:
             case K4A_IMAGE_FORMAT_IR16:
                 dims[0] = k4a_image_get_height_pixels(*img_src);
@@ -505,6 +506,9 @@ extern "C" {
                 break;
             case K4A_IMAGE_FORMAT_COLOR_BGRA32:
                 pixel_size = (int)sizeof(uint32_t);
+                break;
+            case K4A_IMAGE_FORMAT_CUSTOM16:
+                pixel_size = static_cast<int32_t>(sizeof(int16_t));
                 break;
             default:
                 // Not supported
@@ -592,6 +596,80 @@ extern "C" {
         }
         else {
             free(depth_image_transformed);
+            return Py_BuildValue("");
+        }
+    }
+
+    static PyObject* transformation_depth_image_to_color_camera_custom(PyObject* self, PyObject* args){
+        k4a_transformation_t* transformation_handle;
+        PyObject *capsule;
+        int thread_safe;
+        PyThreadState *thread_state;
+        k4a_result_t res;
+        PyArrayObject *d_array;
+        PyArrayObject *c_array;
+        k4a_color_resolution_t color_resolution;
+	k4a_transformation_interpolation_type_t interpolation_type = K4A_TRANSFORMATION_INTERPOLATION_TYPE_NEAREST;
+
+
+        PyArg_ParseTuple(args, "OpO!O!I", &capsule, &thread_safe, &PyArray_Type, &d_array, &PyArray_Type, &c_array, &color_resolution);
+        transformation_handle = (k4a_transformation_t*)PyCapsule_GetPointer(capsule, CAPSULE_TRANSFORMATION_NAME);
+
+        k4a_image_t* depth_image_transformed = (k4a_image_t*) malloc(sizeof(k4a_image_t));
+        k4a_image_t* custom_image_transformed = (k4a_image_t*) malloc(sizeof(k4a_image_t));
+
+        k4a_image_t depth_image;
+        k4a_image_t custom_image;
+        res = numpy_to_k4a_image(d_array, &depth_image, K4A_IMAGE_FORMAT_DEPTH16);
+	if (K4A_RESULT_SUCCEEDED == res) {
+            res = numpy_to_k4a_image(c_array, &custom_image, K4A_IMAGE_FORMAT_CUSTOM16);
+	}
+        thread_state = _gil_release(thread_safe);
+        if (K4A_RESULT_SUCCEEDED == res) {
+            res = k4a_image_create(
+                    k4a_image_get_format(depth_image),
+                    RESOLUTION_TO_DIMS[color_resolution][0],
+                    RESOLUTION_TO_DIMS[color_resolution][1],
+                    RESOLUTION_TO_DIMS[color_resolution][0] * (int)sizeof(uint16_t),
+                    depth_image_transformed);
+        }
+        if (K4A_RESULT_SUCCEEDED == res) {
+            res = k4a_image_create(
+                    k4a_image_get_format(custom_image),
+                    RESOLUTION_TO_DIMS[color_resolution][0],
+                    RESOLUTION_TO_DIMS[color_resolution][1],
+                    RESOLUTION_TO_DIMS[color_resolution][0] * static_cast<int32_t>(sizeof(int16_t)),
+                    custom_image_transformed);
+        }
+
+        if (K4A_RESULT_SUCCEEDED == res) {
+            res = k4a_transformation_depth_image_to_color_camera_custom(
+                    *transformation_handle,
+                    depth_image,
+                    custom_image,
+		    *depth_image_transformed,
+		    *custom_image_transformed,
+		    interpolation_type,
+		    0);
+            k4a_image_release(depth_image);
+            k4a_image_release(custom_image);
+        }
+        _gil_restore(thread_state);
+        PyArrayObject* np_depth_image;
+        PyArrayObject* np_custom_image;
+        if (K4A_RESULT_SUCCEEDED == res) {
+            res = k4a_image_to_numpy(depth_image_transformed, &np_depth_image);
+        }
+        if (K4A_RESULT_SUCCEEDED == res) {
+            res = k4a_image_to_numpy(custom_image_transformed, &np_custom_image);
+        }
+
+        if (K4A_RESULT_SUCCEEDED == res) {
+            return PyArray_Return(np_custom_image);
+        }
+        else {
+            free(depth_image_transformed);
+            free(custom_image_transformed);
             return Py_BuildValue("");
         }
     }
@@ -1148,6 +1226,7 @@ extern "C" {
         {"calibration_get_from_raw", calibration_get_from_raw, METH_VARARGS, "Create new calibration handle from raw json."},
         {"transformation_create", transformation_create, METH_VARARGS, "Create transformation handle from calibration"},
         {"transformation_depth_image_to_color_camera", transformation_depth_image_to_color_camera, METH_VARARGS, "Transforms the depth map into the geometry of the color camera."},
+        {"transformation_depth_image_to_color_camera_custom", transformation_depth_image_to_color_camera_custom, METH_VARARGS, "Transforms the custom & depth map into the geometry of the color camera."},
         {"transformation_color_image_to_depth_camera", transformation_color_image_to_depth_camera, METH_VARARGS, "Transforms the color image into the geometry of the depth camera."},
         {"transformation_depth_image_to_point_cloud", transformation_depth_image_to_point_cloud, METH_VARARGS, "Transforms the depth map to a point cloud."},
         {"calibration_3d_to_3d", calibration_3d_to_3d, METH_VARARGS, "Transforms the coordinates between 2 3D systems"},

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -604,15 +604,24 @@ extern "C" {
         k4a_transformation_t* transformation_handle;
         PyObject *capsule;
         int thread_safe;
+	int interp_nearest;
         PyThreadState *thread_state;
         k4a_result_t res;
         PyArrayObject *d_array;
         PyArrayObject *c_array;
         k4a_color_resolution_t color_resolution;
-	k4a_transformation_interpolation_type_t interpolation_type = K4A_TRANSFORMATION_INTERPOLATION_TYPE_NEAREST;
+	k4a_transformation_interpolation_type_t interpolation_type;
 
 
-        PyArg_ParseTuple(args, "OpO!O!I", &capsule, &thread_safe, &PyArray_Type, &d_array, &PyArray_Type, &c_array, &color_resolution);
+        PyArg_ParseTuple(args, "OpO!O!Ip", &capsule, &thread_safe, &PyArray_Type, &d_array, &PyArray_Type, &c_array, &color_resolution, &interp_nearest);
+
+	if (interp_nearest){
+             interpolation_type = K4A_TRANSFORMATION_INTERPOLATION_TYPE_NEAREST;
+	}
+	else {
+             interpolation_type = K4A_TRANSFORMATION_INTERPOLATION_TYPE_LINEAR;
+	}
+
         transformation_handle = (k4a_transformation_t*)PyCapsule_GetPointer(capsule, CAPSULE_TRANSFORMATION_NAME);
 
         k4a_image_t* depth_image_transformed = (k4a_image_t*) malloc(sizeof(k4a_image_t));

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -674,7 +674,7 @@ extern "C" {
         }
 
         if (K4A_RESULT_SUCCEEDED == res) {
-            return PyArray_Return(np_custom_image);
+            return Py_BuildValue("OO", np_custom_image, np_depth_image);
         }
         else {
             free(depth_image_transformed);

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -508,7 +508,7 @@ extern "C" {
                 pixel_size = (int)sizeof(uint32_t);
                 break;
             case K4A_IMAGE_FORMAT_CUSTOM16:
-                pixel_size = static_cast<int32_t>(sizeof(int16_t));
+                pixel_size = (unsigned int)sizeof(int16_t);
                 break;
             default:
                 // Not supported

--- a/pyk4a/transformation.py
+++ b/pyk4a/transformation.py
@@ -18,14 +18,14 @@ def depth_image_to_color_camera(depth: np.ndarray, calibration: Calibration, thr
 
 
 def depth_image_to_color_camera_custom(
-    depth: np.ndarray, custom: np.ndarray, calibration: Calibration, thread_safe: bool
+        depth: np.ndarray, custom: np.ndarray, calibration: Calibration, thread_safe: bool, interp_nearest: bool = True,
 ) -> Optional[np.ndarray]:
     """
     Transforms depth image and custom image to color_image space
     Return empty result if transformation failed
     """
     return k4a_module.transformation_depth_image_to_color_camera_custom(
-        calibration.transformation_handle, thread_safe, depth, custom, calibration.color_resolution,
+        calibration.transformation_handle, thread_safe, depth, custom, calibration.color_resolution, interp_nearest,
     )
 
 

--- a/pyk4a/transformation.py
+++ b/pyk4a/transformation.py
@@ -18,7 +18,7 @@ def depth_image_to_color_camera(depth: np.ndarray, calibration: Calibration, thr
 
 
 def depth_image_to_color_camera_custom(
-        depth: np.ndarray, custom: np.ndarray, calibration: Calibration, thread_safe: bool, interp_nearest: bool = True,
+    depth: np.ndarray, custom: np.ndarray, calibration: Calibration, thread_safe: bool, interp_nearest: bool = True,
 ) -> Optional[np.ndarray]:
     """
     Transforms depth image and custom image to color_image space

--- a/pyk4a/transformation.py
+++ b/pyk4a/transformation.py
@@ -17,6 +17,18 @@ def depth_image_to_color_camera(depth: np.ndarray, calibration: Calibration, thr
     )
 
 
+def depth_image_to_color_camera_custom(
+    depth: np.ndarray, custom: np.ndarray, calibration: Calibration, thread_safe: bool
+) -> Optional[np.ndarray]:
+    """
+    Transforms depth image and custom image to color_image space
+    Return empty result if transformation failed
+    """
+    return k4a_module.transformation_depth_image_to_color_camera_custom(
+        calibration.transformation_handle, thread_safe, depth, custom, calibration.color_resolution,
+    )
+
+
 def depth_image_to_point_cloud(
     depth: np.ndarray, calibration: Calibration, thread_safe: bool, calibration_type_depth=True
 ) -> Optional[np.ndarray]:


### PR DESCRIPTION
Added the ability to transform IR images to color camera format using the k4a_depth_image_to_color_camera_custom function. There is still work to be done because I am pretty sure the depth image is being transformed as well. So it is redundant to only do this with the ir image. Although I am not sure the best way to return both depth and ir images from the c++ function. TODO in the future.