### PR TITLE
Support for capture images timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 
+
 on:
   pull_request:
   push:
@@ -22,10 +23,10 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v2
       with:
-        key: pip-cache-${{ hashFiles('requirements-dev.txt') }}
+        key: pip-cache-lint-${{ hashFiles('requirements-dev.txt') }}
         path: ~/.cache/pip
         restore-keys: |
-            pip-cache-
+            pip-cache-lint
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v2
       with:
@@ -34,6 +35,10 @@ jobs:
       run: |
         make lint
   test:
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8']
+      fail-fast: true
     name: Test
     runs-on: ubuntu-18.04
     steps:
@@ -45,17 +50,17 @@ jobs:
           env DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y sudo -E apt install -q -y  libk4a1.4-dev
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Setup Python  ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version:  ${{ matrix.python-version }}
       - name: Cache PyPI
         uses: actions/cache@v2
         with:
-          key: pip-cache-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('setup.py') }}
+          key: pip-cache-test-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('setup.py') }}
           path: ~/.cache/pip
           restore-keys: |
-              pip-cache-
+              pip-cache-test-${{ matrix.python-version }}
       - name: Install dependencies
         uses: py-actions/py-dependency-install@v2
         with:
@@ -66,3 +71,7 @@ jobs:
       - name: Run tests
         run: |
           make test-no-hardware
+      - name: Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml # optional

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ lint:
 	mypy $(SOURCES)
 
 test:
-	pytest --cov=pyk4a --verbose $(TESTS)
+	pytest $(TESTS)
 
 test-hardware:
-	pytest --cov=pyk4a  -m "device" --verbose $(TESTS)
+	pytest  -m "device" $(TESTS)
 
 test-no-hardware:
-	pytest --cov=pyk4a  -m "not device" --verbose $(TESTS)
+	pytest -m "not device" $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,5 @@ test-hardware:
 	pytest  -m "device" $(TESTS)
 
 test-no-hardware:
-	pytest -m "not device" $(TESTS)
+	pytest -m "not device and not opengl" $(TESTS)
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # pyk4a
-![CI](https://github.com/etiennedub/pyk4a/workflows/CI/badge.svg)
 
-![pyk4a](https://github.com/etiennedub/pyk4a/raw/master/figs/pyk4a_logo.png)
+![CI](https://github.com/etiennedub/pyk4a/workflows/CI/badge.svg)
+[![codecov](https://codecov.io/gh/etiennedub/pyk4a/branch/master/graph/badge.svg)](https://codecov.io/gh/etiennedub/pyk4a)
+
+![pyk4a](https://github.com/etiennedub/pyk4a/raw/master/figs/pyk4a_logo.png) 
+
 
 This library is a simple and pythonic wrapper in Python 3 for the Azure-Kinect-Sensor-SDK.
 

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -53,14 +53,16 @@ class PyK4ACapture:
     @property
     def depth_point_cloud(self) -> Optional[np.ndarray]:
         if self._depth_point_cloud is None and self.depth is not None:
-            self._depth_point_cloud = depth_image_to_point_cloud(self._depth, self._calibration, self.thread_safe)
+            self._depth_point_cloud = depth_image_to_point_cloud(
+                self._depth, self._calibration, self.thread_safe, calibration_type_depth=True,
+            )
         return self._depth_point_cloud
 
     @property
     def transformed_depth_point_cloud(self) -> Optional[np.ndarray]:
         if self._transformed_depth_point_cloud is None and self.transformed_depth is not None:
-            self._depth_point_cloud = depth_image_to_point_cloud(
-                self.transformed_depth, self._calibration, self.thread_safe
+            self._transformed_depth_point_cloud = depth_image_to_point_cloud(
+                self.transformed_depth, self._calibration, self.thread_safe, calibration_type_depth=False,
             )
         return self._transformed_depth_point_cloud
 

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -19,8 +19,11 @@ class PyK4ACapture:
         self._color_format = color_format
 
         self._color: Optional[np.ndarray] = None
+        self._color_timestamp_usec: int = 0
         self._depth: Optional[np.ndarray] = None
+        self._depth_timestamp_usec: int = 0
         self._ir: Optional[np.ndarray] = None
+        self._ir_timestamp_usec: int = 0
         self._depth_point_cloud: Optional[np.ndarray] = None
         self._transformed_depth: Optional[np.ndarray] = None
         self._transformed_depth_point_cloud: Optional[np.ndarray] = None
@@ -29,20 +32,45 @@ class PyK4ACapture:
     @property
     def color(self) -> Optional[np.ndarray]:
         if self._color is None:
-            self._color = k4a_module.capture_get_color_image(self._capture_handle, self.thread_safe)
+            self._color, self._color_timestamp_usec = k4a_module.capture_get_color_image(
+                self._capture_handle, self.thread_safe
+            )
         return self._color
+
+    @property
+    def color_timestamp_usec(self) -> int:
+        """Device timestamp for color image. Not equal host machine timestamp!"""
+        if self._color is None:
+            self.color
+        return self._color_timestamp_usec
 
     @property
     def depth(self) -> Optional[np.ndarray]:
         if self._depth is None:
-            self._depth = k4a_module.capture_get_depth_image(self._capture_handle, self.thread_safe)
+            self._depth, self._depth_timestamp_usec = k4a_module.capture_get_depth_image(
+                self._capture_handle, self.thread_safe
+            )
         return self._depth
 
     @property
+    def depth_timestamp_usec(self) -> int:
+        """Device timestamp for depth image. Not equal host machine timestamp!. Like as equal IR image timestamp"""
+        if self._depth is None:
+            self.depth
+        return self._depth_timestamp_usec
+
+    @property
     def ir(self) -> Optional[np.ndarray]:
+        """Device timestamp for IR image. Not equal host machine timestamp!. Like as equal depth image timestamp"""
         if self._ir is None:
-            self._ir = k4a_module.capture_get_ir_image(self._capture_handle, self.thread_safe)
+            self._ir, self._ir_timestamp_usec = k4a_module.capture_get_ir_image(self._capture_handle, self.thread_safe)
         return self._ir
+
+    @property
+    def ir_timestamp_usec(self) -> int:
+        if self._ir is None:
+            self.ir
+        return self._ir_timestamp_usec
 
     @property
     def transformed_depth(self) -> Optional[np.ndarray]:

--- a/pyk4a/playback.py
+++ b/pyk4a/playback.py
@@ -155,7 +155,7 @@ class PyK4APlayback:
         result, capture_handle = k4a_module.playback_get_next_capture(self._handle, self.thread_safe)
         self._verify_stream_error(result)
         return PyK4ACapture(
-            calibration=self._calibration,
+            calibration=self.calibration,
             capture_handle=capture_handle,
             color_format=self.configuration["color_format"],
             thread_safe=self.thread_safe,
@@ -166,7 +166,7 @@ class PyK4APlayback:
         result, capture_handle = k4a_module.playback_get_previous_capture(self._handle, self.thread_safe)
         self._verify_stream_error(result)
         return PyK4ACapture(
-            calibration=self._calibration,
+            calibration=self.calibration,
             capture_handle=capture_handle,
             color_format=self.configuration["color_format"],
             thread_safe=self.thread_safe,

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -706,6 +706,7 @@ extern "C" {
         k4a_capture_t* capture_handle;
         PyObject *capsule;
         int thread_safe;
+        uint64_t device_timestamp_usec = 0;
         PyThreadState *thread_state;
         k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -715,7 +716,7 @@ extern "C" {
         k4a_image_t* image = (k4a_image_t*) malloc(sizeof(k4a_image_t));
         if (image == NULL) {
             fprintf(stderr, "Cannot allocate memory");
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
 
         thread_state = _gil_release(thread_safe);
@@ -728,11 +729,12 @@ extern "C" {
         }
 
         if (K4A_RESULT_SUCCEEDED == res) {
-            return PyArray_Return(np_image);
+            device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
+            return Py_BuildValue("NK", np_image, device_timestamp_usec);
         }
         else {
             free(image);
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
     }
 
@@ -740,6 +742,7 @@ extern "C" {
         k4a_capture_t* capture_handle;
         PyObject *capsule;
         int thread_safe;
+        uint64_t device_timestamp_usec = 0;
         PyThreadState *thread_state;
         k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -749,7 +752,7 @@ extern "C" {
         k4a_image_t* image = (k4a_image_t*) malloc(sizeof(k4a_image_t));
         if (image == NULL) {
             fprintf(stderr, "Cannot allocate memory");
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
 
         thread_state = _gil_release(thread_safe);
@@ -762,11 +765,12 @@ extern "C" {
         }
 
         if (K4A_RESULT_SUCCEEDED == res) {
-            return PyArray_Return(np_image);
+            device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
+            return Py_BuildValue("NK", np_image, device_timestamp_usec);
         }
         else {
             free(image);
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
     }
 
@@ -774,6 +778,7 @@ extern "C" {
         k4a_capture_t* capture_handle;
         PyObject *capsule;
         int thread_safe;
+        uint64_t device_timestamp_usec = 0;
         PyThreadState *thread_state;
         k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -783,7 +788,7 @@ extern "C" {
         k4a_image_t* image = (k4a_image_t*) malloc(sizeof(k4a_image_t));
         if (image == NULL) {
             fprintf(stderr, "Cannot allocate memory");
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
 
         thread_state = _gil_release(thread_safe);
@@ -796,11 +801,12 @@ extern "C" {
         }
 
         if (K4A_RESULT_SUCCEEDED == res) {
-            return PyArray_Return(np_image);
+            device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
+            return Py_BuildValue("NK", np_image, device_timestamp_usec);
         }
         else {
             free(image);
-            return Py_BuildValue("");
+            return Py_BuildValue("NK", Py_None, device_timestamp_usec);
         }
     }
 
@@ -887,6 +893,7 @@ extern "C" {
         // Return object...
         return Py_BuildValue("II(fff)", res, valid, target_point3d_mm.xyz.x, target_point3d_mm.xyz.y, target_point3d_mm.xyz.z);
     }
+
 
     static PyObject* playback_open(PyObject* self, PyObject *args) {
         int thread_safe;

--- a/pyk4a/transformation.py
+++ b/pyk4a/transformation.py
@@ -17,13 +17,15 @@ def depth_image_to_color_camera(depth: np.ndarray, calibration: Calibration, thr
     )
 
 
-def depth_image_to_point_cloud(depth: np.ndarray, calibration: Calibration, thread_safe: bool) -> Optional[np.ndarray]:
+def depth_image_to_point_cloud(
+    depth: np.ndarray, calibration: Calibration, thread_safe: bool, calibration_type_depth=True
+) -> Optional[np.ndarray]:
     """
     Transform depth color_image to point cloud
     Return empty result if transformation failed
     """
     return k4a_module.transformation_depth_image_to_point_cloud(
-        calibration.transformation_handle, thread_safe, depth, True
+        calibration.transformation_handle, thread_safe, depth, calibration_type_depth,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ line-length = 120
 
 [tool.pytest.ini_options]
 markers = [
-        "device: Tests require connected real device"
+        "device: Tests require connected real device",
+        "opengl: Tests require opengl for GPU accelerated depth engine software"
 ]
 addopts = "--cov=pyk4a --cov-report=xml --verbose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ line-length = 120
 markers = [
         "device: Tests require connected real device"
 ]
+addopts = "--cov=pyk4a --cov-report=xml --verbose"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ mypy==0.782
 mypy-extensions==0.4.3
 pytest==6.0.1
 pytest-cov==2.10.1
+dataclasses==0.6; python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@ import sys
 if sys.version_info[0] == 2:
     sys.exit("Python 2 is not supported.")
 
+# Enables --editable install with --user
+# https://github.com/pypa/pip/issues/7953
+import site
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
 # Bypass import numpy before running install_requires
 # https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy
 class get_numpy_include:
@@ -18,7 +23,7 @@ module = Extension('k4a_module',
                    libraries=['k4a', 'k4arecord'])
 
 setup(name='pyk4a',
-      version='1.0',
+      version='1.0.1',
       description='Python wrapper over Azure Kinect SDK',
       license='GPL-3.0',
       author='Etienne Dubeau',
@@ -26,7 +31,7 @@ setup(name='pyk4a',
       python_requires='>=3.4',
       author_email='etienne.dubeau.1@ulaval.ca',
       url='https://github.com/etiennedub/pyk4a/',
-      download_url='https://github.com/etiennedub/pyk4a/archive/0.2.tar.gz',
+      download_url='https://github.com/etiennedub/pyk4a/archive/1.0.1.tar.gz',
       packages=['pyk4a'],
       package_data={'pyk4a': ["py.typed"]},
       ext_modules=[module],

--- a/tests/functional/test_calibration.py
+++ b/tests/functional/test_calibration.py
@@ -26,6 +26,7 @@ class TestCalibration:
         assert calibration
 
     @staticmethod
+    @pytest.mark.opengl
     def test_creating_transfromation_handle(calibration: Calibration):
         transformation = calibration.transformation_handle
         assert transformation is not None

--- a/tests/functional/test_capture.py
+++ b/tests/functional/test_capture.py
@@ -7,6 +7,7 @@ from pyk4a import PyK4A
 class TestCapture:
     @staticmethod
     @pytest.mark.device
+    @pytest.mark.opengl
     def test_device_capture_images(device: PyK4A):
         device.open()
         device._start_cameras()

--- a/tests/functional/test_device.py
+++ b/tests/functional/test_device.py
@@ -60,6 +60,7 @@ class TestProperties:
 class TestCameras:
     @staticmethod
     @pytest.mark.device
+    @pytest.mark.opengl
     def test_start_stop_cameras(device: PyK4A):
         device.open()
         device._start_cameras()
@@ -67,6 +68,7 @@ class TestCameras:
 
     @staticmethod
     @pytest.mark.device
+    @pytest.mark.opengl
     def test_capture(device: PyK4A):
         device.open()
         device._start_cameras()
@@ -77,6 +79,7 @@ class TestCameras:
 class TestIMU:
     @staticmethod
     @pytest.mark.device
+    @pytest.mark.opengl
     def test_start_stop_imu(device: PyK4A):
         device.open()
         device._start_cameras()  # imu will not work without cameras
@@ -86,6 +89,7 @@ class TestIMU:
 
     @staticmethod
     @pytest.mark.device
+    @pytest.mark.opengl
     def test_get_imu_sample(device: PyK4A):
         device.open()
         device._start_cameras()

--- a/tests/functional/test_playback.py
+++ b/tests/functional/test_playback.py
@@ -113,6 +113,9 @@ class TestGetCapture:
         assert capture is not None
         assert capture.depth is not None
         assert capture.color is not None
+        assert capture.depth_timestamp_usec == 800222
+        assert capture.color_timestamp_usec == 800222
+        assert capture.ir_timestamp_usec == 800222
         assert capture._calibration is not None  # Issue #81
 
     @staticmethod

--- a/tests/functional/test_playback.py
+++ b/tests/functional/test_playback.py
@@ -103,3 +103,24 @@ class TestSeek:
         playback.seek(1, origin=SeekOrigin.DEVICE_TIME)  # TODO add correct timestamp from datablock here
         capture = playback.get_next_capture()
         assert capture.color is not None
+
+
+class TestGetCapture:
+    @staticmethod
+    def test_get_next_capture(playback: PyK4APlayback):
+        playback.open()
+        capture = playback.get_next_capture()
+        assert capture is not None
+        assert capture.depth is not None
+        assert capture.color is not None
+        assert capture._calibration is not None  # Issue #81
+
+    @staticmethod
+    def test_get_previouse_capture(playback: PyK4APlayback):
+        playback.open()
+        playback.seek(0, origin=SeekOrigin.END)
+        capture = playback.get_previouse_capture()
+        assert capture is not None
+        assert capture.depth is not None
+        assert capture.color is not None
+        assert capture._calibration is not None  # Issue #81

--- a/tests/plugins/device.py
+++ b/tests/plugins/device.py
@@ -232,7 +232,10 @@ def patch_module_device(monkeypatch, calibration_raw, capture_factory):
             assert self._opened is True
             if not self._cameras_started:
                 return Result.Failed.value, None
-            return Result.Success.value, (36.6, (0.1, 9.8, 0.005), time.time_ns(), (0.1, 0.2, 0.3), time.time_ns())
+            return (
+                Result.Success.value,
+                (36.6, (0.1, 9.8, 0.005), int(time.time() * 1e6), (0.1, 0.2, 0.3), int(time.time() * 1e6)),
+            )
 
         def device_get_calibration(self, depth_mode: int, color_resolution: int) -> Tuple[int, Optional[object]]:
             assert self._opened is True


### PR DESCRIPTION
This  PR add properties XXX_timestamp_usec which return device timestamp for corresponding images.
Timestamps are device specific and cannot be compared with computer timestamp. 

Also new mark for  "opengl" for pytest added. For transformation-related function Azure Kinect SDK use own depth engine, which require GPU. This mark helps disable some tests for CI   