### PR TITLE
Add functions to access system timestamps for each image

### DIFF
--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -26,12 +26,15 @@ class PyK4ACapture:
 
         self._color: Optional[np.ndarray] = None
         self._color_timestamp_usec: int = 0
+        self._color_system_timestamp_nsec: int = 0
         self._color_exposure_usec: Optional[int] = None
         self._color_white_balance: Optional[int] = None
         self._depth: Optional[np.ndarray] = None
         self._depth_timestamp_usec: int = 0
+        self._depth_system_timestamp_nsec: int = 0
         self._ir: Optional[np.ndarray] = None
         self._ir_timestamp_usec: int = 0
+        self._ir_system_timestamp_nsec: int = 0
         self._depth_point_cloud: Optional[np.ndarray] = None
         self._transformed_depth: Optional[np.ndarray] = None
         self._transformed_depth_point_cloud: Optional[np.ndarray] = None
@@ -41,9 +44,11 @@ class PyK4ACapture:
     @property
     def color(self) -> Optional[np.ndarray]:
         if self._color is None:
-            self._color, self._color_timestamp_usec = k4a_module.capture_get_color_image(
-                self._capture_handle, self.thread_safe
-            )
+            (
+                self._color,
+                self._color_timestamp_usec,
+                self._color_system_timestamp_nsec,
+            ) = k4a_module.capture_get_color_image(self._capture_handle, self.thread_safe)
         return self._color
 
     @property
@@ -52,6 +57,13 @@ class PyK4ACapture:
         if self._color is None:
             self.color
         return self._color_timestamp_usec
+
+    @property
+    def color_system_timestamp_nsec(self) -> int:
+        """System timestamp for color image in nanoseconds. Corresponds to Python's time.perf_counter_ns()."""
+        if self._color is None:
+            self.color
+        return self._color_system_timestamp_nsec
 
     @property
     def color_exposure_usec(self) -> int:
@@ -74,9 +86,11 @@ class PyK4ACapture:
     @property
     def depth(self) -> Optional[np.ndarray]:
         if self._depth is None:
-            self._depth, self._depth_timestamp_usec = k4a_module.capture_get_depth_image(
-                self._capture_handle, self.thread_safe
-            )
+            (
+                self._depth,
+                self._depth_timestamp_usec,
+                self._depth_system_timestamp_nsec,
+            ) = k4a_module.capture_get_depth_image(self._capture_handle, self.thread_safe)
         return self._depth
 
     @property
@@ -87,10 +101,19 @@ class PyK4ACapture:
         return self._depth_timestamp_usec
 
     @property
+    def depth_system_timestamp_nsec(self) -> int:
+        """System timestamp for depth image in nanoseconds. Corresponds to Python's time.perf_counter_ns()."""
+        if self._depth is None:
+            self.depth
+        return self._depth_system_timestamp_nsec
+
+    @property
     def ir(self) -> Optional[np.ndarray]:
         """Device timestamp for IR image. Not equal host machine timestamp!. Like as equal depth image timestamp"""
         if self._ir is None:
-            self._ir, self._ir_timestamp_usec = k4a_module.capture_get_ir_image(self._capture_handle, self.thread_safe)
+            self._ir, self._ir_timestamp_usec, self._ir_system_timestamp_nsec = k4a_module.capture_get_ir_image(
+                self._capture_handle, self.thread_safe
+            )
         return self._ir
 
     @property
@@ -98,6 +121,13 @@ class PyK4ACapture:
         if self._ir is None:
             self.ir
         return self._ir_timestamp_usec
+
+    @property
+    def ir_system_timestamp_nsec(self) -> int:
+        """System timestamp for IR image in nanoseconds. Corresponds to Python's time.perf_counter_ns()."""
+        if self._ir is None:
+            self.ir
+        return self._ir_system_timestamp_nsec
 
     @property
     def transformed_depth(self) -> Optional[np.ndarray]:

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -838,6 +838,7 @@ static PyObject *capture_get_color_image(PyObject *self, PyObject *args) {
   PyObject *capsule;
   int thread_safe;
   uint64_t device_timestamp_usec = 0;
+  uint64_t system_timestamp_nsec = 0;
   PyThreadState *thread_state;
   k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -847,7 +848,7 @@ static PyObject *capture_get_color_image(PyObject *self, PyObject *args) {
   k4a_image_t *image = (k4a_image_t *)malloc(sizeof(k4a_image_t));
   if (image == NULL) {
     fprintf(stderr, "Cannot allocate memory");
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 
   thread_state = _gil_release(thread_safe);
@@ -861,10 +862,11 @@ static PyObject *capture_get_color_image(PyObject *self, PyObject *args) {
 
   if (K4A_RESULT_SUCCEEDED == res) {
     device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
-    return Py_BuildValue("NK", np_image, device_timestamp_usec);
+    system_timestamp_nsec = k4a_image_get_system_timestamp_nsec(*image);
+    return Py_BuildValue("NKK", np_image, device_timestamp_usec, system_timestamp_nsec);
   } else {
     free(image);
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 }
 
@@ -873,6 +875,7 @@ static PyObject *capture_get_depth_image(PyObject *self, PyObject *args) {
   PyObject *capsule;
   int thread_safe;
   uint64_t device_timestamp_usec = 0;
+  uint64_t system_timestamp_nsec = 0;
   PyThreadState *thread_state;
   k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -882,7 +885,7 @@ static PyObject *capture_get_depth_image(PyObject *self, PyObject *args) {
   k4a_image_t *image = (k4a_image_t *)malloc(sizeof(k4a_image_t));
   if (image == NULL) {
     fprintf(stderr, "Cannot allocate memory");
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 
   thread_state = _gil_release(thread_safe);
@@ -896,10 +899,11 @@ static PyObject *capture_get_depth_image(PyObject *self, PyObject *args) {
 
   if (K4A_RESULT_SUCCEEDED == res) {
     device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
-    return Py_BuildValue("NK", np_image, device_timestamp_usec);
+    system_timestamp_nsec = k4a_image_get_system_timestamp_nsec(*image);
+    return Py_BuildValue("NKK", np_image, device_timestamp_usec, system_timestamp_nsec);
   } else {
     free(image);
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 }
 
@@ -908,6 +912,7 @@ static PyObject *capture_get_ir_image(PyObject *self, PyObject *args) {
   PyObject *capsule;
   int thread_safe;
   uint64_t device_timestamp_usec = 0;
+  uint64_t system_timestamp_nsec = 0;
   PyThreadState *thread_state;
   k4a_result_t res = K4A_RESULT_FAILED;
 
@@ -917,7 +922,7 @@ static PyObject *capture_get_ir_image(PyObject *self, PyObject *args) {
   k4a_image_t *image = (k4a_image_t *)malloc(sizeof(k4a_image_t));
   if (image == NULL) {
     fprintf(stderr, "Cannot allocate memory");
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 
   thread_state = _gil_release(thread_safe);
@@ -931,10 +936,11 @@ static PyObject *capture_get_ir_image(PyObject *self, PyObject *args) {
 
   if (K4A_RESULT_SUCCEEDED == res) {
     device_timestamp_usec = k4a_image_get_device_timestamp_usec(*image);
-    return Py_BuildValue("NK", np_image, device_timestamp_usec);
+    system_timestamp_nsec = k4a_image_get_system_timestamp_nsec(*image);
+    return Py_BuildValue("NKK", np_image, device_timestamp_usec, system_timestamp_nsec);
   } else {
     free(image);
-    return Py_BuildValue("NK", Py_None, device_timestamp_usec);
+    return Py_BuildValue("NKK", Py_None, device_timestamp_usec, system_timestamp_nsec);
   }
 }
 


### PR DESCRIPTION
The system timestamps in nanoseconds are available from the C SDK using the [`k4a_image_get_system_timestamp_nsec()` function](https://microsoft.github.io/Azure-Kinect-Sensor-SDK/master/group___functions_ga98ba229d1ee1cf3b7c27a0f95e14826b.html#ga98ba229d1ee1cf3b7c27a0f95e14826b). These correspond quite well to Python's [`time.perf_counter_ns()`](https://docs.python.org/3/library/time.html#time.perf_counter_ns), so I suppose they should be useful in Python as well (e.g. for synchronization with other cameras).