### PR TITLE
WIP: Add methods for configuring record metadata

### DIFF
--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -1409,6 +1409,30 @@ static PyObject *record_write_capture(PyObject *self, PyObject *args) {
   return Py_BuildValue("I", result);
 }
 
+static PyObject *record_add_tag(PyObject *self, PyObject *args) {
+  PyObject *record_capsule;
+  k4a_record_t *record_handle;
+  k4a_result_t result;
+  const char *tag_name;
+  const char *tag_value;
+  PyArg_ParseTuple(args, "Oss", &record_capsule, &tag_name, &tag_value);
+  record_handle = (k4a_record_t *)PyCapsule_GetPointer(record_capsule, CAPSULE_RECORD_NAME);
+  result = k4a_record_add_tag(*record_handle, tag_name, tag_value);
+  return Py_BuildValue("I", result);
+}
+
+static PyObject *record_add_attachment(PyObject *self, PyObject *args) {
+  PyObject *record_capsule;
+  k4a_record_t *record_handle;
+  k4a_result_t result;
+  const char *attachment_name;
+  Py_buffer buffer;
+  PyArg_ParseTuple(args, "Osy*", &record_capsule, &attachment_name, &buffer);
+  record_handle = (k4a_record_t *)PyCapsule_GetPointer(record_capsule, CAPSULE_RECORD_NAME);
+  result = k4a_record_add_attachment(*record_handle, attachment_name, (uint8_t *)buffer.buf, buffer.len);
+  return Py_BuildValue("I", result);
+}
+
 struct module_state {
   PyObject *error;
 };
@@ -1479,6 +1503,8 @@ static PyMethodDef Pyk4aMethods[] = {
     {"record_write_header", record_write_header, METH_VARARGS, "Writes the recording header and metadata to file"},
     {"record_flush", record_flush, METH_VARARGS, "Flushes all pending recording data to disk"},
     {"record_write_capture", record_write_capture, METH_VARARGS, "Writes a camera capture to file"},
+    {"record_add_tag", record_add_tag, METH_VARARGS, "Adds a tag to the recording"},
+    {"record_add_attachment", record_add_attachment, METH_VARARGS, "Adds an attachment to the recording"},
     {"device_get_installed_count", device_get_installed_count, METH_VARARGS, "Gets the number of connected devices"},
     {"device_get_serialnum", device_get_serialnum, METH_VARARGS, "Get the Azure Kinect device serial number."},
 

--- a/tests/functional/test_record.py
+++ b/tests/functional/test_record.py
@@ -50,3 +50,29 @@ class TestFlush:
         created_record.flush()
         size_after = created_record.path.stat().st_size
         assert size_after > size_before
+
+
+class TestAddTag:
+    @staticmethod
+    def test_adding_tag(created_record: PyK4ARecord, capture: PyK4ACapture):
+        created_record.add_tag("MYTAG", "Some tag value")
+        created_record.write_header()
+        created_record.write_capture(capture)
+        created_record.close()
+        bytes = created_record.path.read_bytes()
+        # very simple
+        assert b"MYTAG" in bytes, f"Tag MYTAG not found in {created_record.path}"
+        assert b"Some tag value" in bytes, f"Tag value not found in {created_record.path}"
+
+
+class TestAddAttachment:
+    @staticmethod
+    def test_adding_tag(created_record: PyK4ARecord, capture: PyK4ACapture):
+        created_record.add_attachment("file.txt", b"Some text value")
+        created_record.write_header()
+        created_record.write_capture(capture)
+        created_record.close()
+        bytes = created_record.path.read_bytes()
+        # very simple
+        assert b"file.txt" in bytes, f"Attached file.txt not found in {created_record.path}"
+        assert b"Some text value" in bytes, f"Attached file content not found in {created_record.path}"

--- a/tests/functional/test_rerecord.py
+++ b/tests/functional/test_rerecord.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from pyk4a import Config, PyK4APlayback, PyK4ARecord
+
+
+@pytest.fixture()
+def record_path(tmp_path: Path) -> Path:
+    return "/tmp/1.mkv"  # tmp_path / "record.mkv"
+
+
+def test_transfering_calibration(playback: PyK4APlayback, record_path: Path):
+    playback.open()
+    calibration_raw = playback.calibration_raw
+    config = Config(
+        color_format=playback.configuration["color_format"],
+        color_resolution=playback.configuration["color_resolution"],
+        depth_mode=playback.configuration["depth_mode"],
+        camera_fps=playback.configuration["camera_fps"],
+        depth_delay_off_color_usec=playback.configuration["depth_delay_off_color_usec"],
+        wired_sync_mode=playback.configuration["wired_sync_mode"],
+    )
+
+    record = PyK4ARecord(record_path, config=config)
+    record.create()
+    record.add_tag("K4A_CALIBRATION_FILED", "calibration.json")
+    record.add_attachment("calibration.json", calibration_raw.encode())
+    while True:
+        try:
+            capture = playback.get_next_capture()
+            record.write_capture(capture)
+        except EOFError:
+            break
+    playback.close()
+    record.close()
+    replay = PyK4APlayback(record_path)
+    replay.open()
+    assert replay.calibration_raw == calibration_raw, "Calibrations doesn't transferred"

--- a/tests/functional/test_rerecord.py
+++ b/tests/functional/test_rerecord.py
@@ -7,7 +7,7 @@ from pyk4a import Config, PyK4APlayback, PyK4ARecord
 
 @pytest.fixture()
 def record_path(tmp_path: Path) -> Path:
-    return "/tmp/1.mkv"  # tmp_path / "record.mkv"
+    return tmp_path / "record.mkv"
 
 
 def test_transfering_calibration(playback: PyK4APlayback, record_path: Path):

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -94,3 +94,43 @@ class TestFlush:
     def test_not_created_record(record: PyK4ARecord):
         with pytest.raises(K4AException, match=r"not created"):
             record.flush()
+
+
+class TestAddTag:
+    @staticmethod
+    def test_not_created_record(record: PyK4ARecord):
+        with pytest.raises(K4AException, match=r"not created"):
+            record.add_tag("TAG", "value1")
+
+    @staticmethod
+    def test_header_already_written(record: PyK4ARecord):
+        record.create()
+        record.write_header()
+        with pytest.raises(K4AException, match="before the recording header is written"):
+            record.add_tag("TAG", "value1")
+
+    @staticmethod
+    def test_name_not_uppercase(record: PyK4ARecord):
+        record.create()
+        with pytest.raises(K4AException, match="ALL CAPS"):
+            record.add_tag("tag", "value1")
+
+    @staticmethod
+    def test_name_not_alphanum(record: PyK4ARecord):
+        record.create()
+        with pytest.raises(K4AException, match="Tag name may only contain"):
+            record.add_tag("TAG!", "value1")
+
+
+class TestAddAttachment:
+    @staticmethod
+    def test_not_created_record(record: PyK4ARecord):
+        with pytest.raises(K4AException, match=r"not created"):
+            record.add_attachment("file.txt", b"value1")
+
+    @staticmethod
+    def test_header_already_written(record: PyK4ARecord):
+        record.create()
+        record.write_header()
+        with pytest.raises(K4AException, match="before the recording header is written"):
+            record.add_attachment("file.txt", b"value1")


### PR DESCRIPTION
For PyK4ARecord added new methods which allow to configure mkv metadata: `add_tag()` and `add_attachment()`

Now you can create record based on existing record i.e. for filtration and dropping some frames. See `test_transfering_calibration()`
