### PR TITLE
Native library bundling and CI job for os dependent wheel distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ 'windows-latest' ] # 'ubuntu-latest' "ubuntu-18.04"
+        os: [ 'ubuntu-18.04' ] # 'ubuntu-latest' "ubuntu-18.04" "windows-latest"
         python-version: [ '3.8' ] # [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version Tag'
+        required: false
+        default: '1.3.0-bundle'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ 'windows-latest' ] # 'ubuntu-latest' "ubuntu-18.04"
+        python-version: [ '3.8' ] # [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ github.event.inputs.tag }} python ${{ matrix.python-version }} on ${{ matrix.os }}
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Switch to Workspace
+        run: |
+          echo ${{ github.workspace }}
+          cd ${{ github.workspace }}
+
+      # install prerequisites
+      - name: Preqrequisites Ubuntu-18.04
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt install -q -y curl software-properties-common build-essential
+          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          sudo apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod
+          env DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y sudo -E apt install -q -y  libk4a1.4-dev
+
+      - name: Preqrequisites Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install wget --no-progress
+          $ProgressPreference = 'SilentlyContinue'
+          wget https://download.microsoft.com/download/3/d/6/3d6d9e99-a251-4cf3-8c6a-8e108e960b4b/Azure%20Kinect%20SDK%201.4.1.exe -O sdk.exe
+          echo "installing Azure Kinect SDK..."
+          ./sdk.exe  /install /passive /norestart /log ${{ github.workspace }}/azurelog.txt
+          Wait-Process -Name "sdk" -Timeout 360
+          cat ${{ github.workspace }}/azurelog.txt
+
+      # run build command
+      - name: Build pyk4a
+        run: |
+          python -m pip install wheel numpy
+          python setup.py bdist_wheel
+          ls dist
+
+      # upload dist
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*.whl
+          tag: ${{ github.event.inputs.tag }}
+          release_name: "Version ${{ github.event.inputs.tag }}"
+          body: "Prebuilt pyk4a wheel packages version ${{ github.event.inputs.tag }}."
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04' ] # 'ubuntu-latest' "ubuntu-18.04" "windows-latest"
-        python-version: [ '3.8' ] # [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [ 'ubuntu-18.04', 'windows-latest' ] # 'ubuntu-latest' "ubuntu-18.04" "windows-latest"
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.dll
 
 # Distribution / packaging
 .eggs/

--- a/pyk4a/module.py
+++ b/pyk4a/module.py
@@ -1,16 +1,21 @@
+import os
 import sys
+from pathlib import Path
 
+import pyk4a
 
 try:
     import k4a_module  # noqa: F401
 except BaseException as e:
-    if sys.platform == "win32":
-        from .win32_utils import prepare_import_k4a_module
 
-        added_dll_dir = prepare_import_k4a_module()
-        try:
-            import k4a_module  # noqa: F401
-        except BaseException:
+    added_dll_dir = Path(os.path.abspath(os.path.dirname(pyk4a.__file__)))
+
+    try:
+        from .win32_utils import add_dll_directory
+        add_dll_directory(added_dll_dir)
+        import k4a_module  # noqa: F401
+    except BaseException:
+        if sys.platform == "win32":
             raise ImportError(
                 (
                     "Cannot import k4a_module. "
@@ -20,12 +25,12 @@ except BaseException as e:
                     "Also make sure pyk4a was properly built."
                 )
             ) from e
-    else:
-        raise ImportError(
-            (
-                "Cannot import k4a_module. "
-                "Make sure `libk4a.so` can be found. "
-                "Add the directory to your `LD_LIBRARY_PATH` if required. "
-                "Also make sure pyk4a is properly built."
-            )
-        ) from e
+        else:
+            raise ImportError(
+                (
+                    "Cannot import k4a_module. "
+                    "Make sure `libk4a.so` can be found. "
+                    "Add the directory to your `LD_LIBRARY_PATH` if required. "
+                    "Also make sure pyk4a is properly built."
+                )
+            ) from e

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import shutil
 
 from setuptools import setup, Extension
 from pathlib import Path
@@ -76,19 +77,25 @@ def bundle_release_libraries(package_data: Dict):
         binary_dir = Path(library_dir).parent / "bin"
     elif system_name == "Linux":
         binary_ext = "*.so"
-        binary_dir = ""
+        binary_dir = Path("/")
         raise NotImplementedError("Linux currently not supported.")
     else:
         raise Exception(f"OS {system_name} not supported.")
 
     # add libraries to package
-    package_data[package_name] = list(glob.glob(str(Path(binary_dir) / binary_ext)))
+    for file in glob.glob(str(Path(binary_dir) / binary_ext)):
+        shutil.copy(file, package_name)
+
+    package_data[package_name] = [binary_ext]
 
 
 # include native libraries
 package_name = "pyk4a"
 package_data = {}
-bundle_release_libraries(package_data)
+
+if "bdist_wheel" in sys.argv:
+    print("adding native files to package")
+    bundle_release_libraries(package_data)
 
 include_dirs = [get_numpy_include()]
 library_dirs = []


### PR DESCRIPTION
As already mentioned in #157 , this PR adds support for native libraries bundled within the package, as well as a multi-os (Windows / Unix) build CI task for github.

At the moment the build task creates wheels for x64 Windows and Linux operating systems and uploads the resulting wheel files into a new release on github. I guess it would make sense to have the following features implemented as well, but it would make sense if the maintainer would define / approve them first:

- Use [tag trigger](https://stackoverflow.com/a/49514965/1138326) to create a new release by setting a tag
- Add [pypi-publish](https://github.com/marketplace/actions/pypi-publish) to the build CI to directly upload the binary files to pypi
- Implement an [add-all method](https://github.com/cansik/pyk4a/blob/master/pyk4a/module.py#L33-L35) to directly load all .so files in the package directory (as on Windows) to not be dependent on version numbers
- Maybe re-implement the possibility to use the system Azure libs on Windows (currently I replaced them by the bundled ones)?