### PR TITLE
Color image ISO speed for Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Homepage: https://github.com/etiennedub/pyk4a/
 
 ## Prerequisites
 The [Azure-Kinect-Sensor-SDK](https://github.com/microsoft/Azure-Kinect-Sensor-SDK) is required to build this library.
-To use the SDK, refer to the installation instructions [here](https://github.com/microsoft/Azure-Kinect-Sensor-SDK).
+To use the SDK, refer to the installation instructions [here](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md).
 
 
 ## Install

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -27,6 +27,7 @@ class PyK4ACapture:
         self._color_timestamp_usec: int = 0
         self._color_system_timestamp_nsec: int = 0
         self._color_exposure_usec: Optional[int] = None
+        self._color_iso_speed: Optional[int] = None
         self._color_white_balance: Optional[int] = None
         self._depth: Optional[np.ndarray] = None
         self._depth_timestamp_usec: int = 0
@@ -72,6 +73,21 @@ class PyK4ACapture:
                 raise K4AException("Cannot read exposure from color image")
             self._color_exposure_usec = value
         return self._color_exposure_usec
+
+    @property
+    def color_iso_speed(self) -> int:
+        """
+        Returns the ISO speed of the image. 0 indicates the ISO speed was not available or an error occurred.
+
+        This function is only valid for color captures, and not for depth or IR captures.
+        """
+        if self._color_iso_speed is None:
+            value = k4a_module.color_image_get_iso_speed(self._capture_handle)
+            print(value)
+            if value == 0:
+                raise K4AException("Cannot read iso from color_image")
+            self._color_iso_speed = value
+        return self._color_iso_speed
 
     @property
     def color_white_balance(self) -> int:

--- a/pyk4a/capture.py
+++ b/pyk4a/capture.py
@@ -76,14 +76,8 @@ class PyK4ACapture:
 
     @property
     def color_iso_speed(self) -> int:
-        """
-        Returns the ISO speed of the image. 0 indicates the ISO speed was not available or an error occurred.
-
-        This function is only valid for color captures, and not for depth or IR captures.
-        """
         if self._color_iso_speed is None:
             value = k4a_module.color_image_get_iso_speed(self._capture_handle)
-            print(value)
             if value == 0:
                 raise K4AException("Cannot read iso from color_image")
             self._color_iso_speed = value

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -587,6 +587,23 @@ static PyObject *color_image_get_exposure_usec(PyObject *self, PyObject *args) {
   return Py_BuildValue("K", exposure_usec);
 }
 
+static PyObject *color_image_get_iso_speed(PyObject *self, PyObject *args) {
+  k4a_capture_t *capture_handle;
+  PyObject *capsule;
+  uint64_t iso_speed = 0;
+  PyArg_ParseTuple(args, "O", &capsule);
+  capture_handle = (k4a_capture_t *)PyCapsule_GetPointer(capsule, CAPSULE_CAPTURE_NAME);
+
+  k4a_image_t image = k4a_capture_get_color_image(*capture_handle);
+  if (image == NULL) {
+    fprintf(stderr, "Color image missed");
+    return Py_BuildValue("K", iso_speed);
+  }
+  iso_speed = k4a_image_get_iso_speed(image);
+  k4a_image_release(image);
+  return Py_BuildValue("K", iso_speed);
+}
+
 static PyObject *color_image_get_white_balance(PyObject *self, PyObject *args) {
   k4a_capture_t *capture_handle;
   PyObject *capsule;
@@ -1499,6 +1516,7 @@ static PyMethodDef Pyk4aMethods[] = {
     {"playback_get_next_imu_sample", playback_get_next_imu_sample, METH_VARARGS, "Get next imu sample from playback"},
     {"color_image_get_exposure_usec", color_image_get_exposure_usec, METH_VARARGS,
      "Get color image exposure in microseconds"},
+    {"color_image_get_iso_speed", color_image_get_iso_speed, METH_VARARGS, "Get ISO speed"},
     {"color_image_get_white_balance", color_image_get_white_balance, METH_VARARGS, "Get color image white balance"},
     {"record_create", record_create, METH_VARARGS, "Opens a new recording file for writing"},
     {"record_close", record_close, METH_VARARGS, "Opens a new recording file for writing"},

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -590,18 +590,18 @@ static PyObject *color_image_get_exposure_usec(PyObject *self, PyObject *args) {
 static PyObject *color_image_get_iso_speed(PyObject *self, PyObject *args) {
   k4a_capture_t *capture_handle;
   PyObject *capsule;
-  uint64_t iso_speed = 0;
+  uint32_t iso_speed = 0;
   PyArg_ParseTuple(args, "O", &capsule);
   capture_handle = (k4a_capture_t *)PyCapsule_GetPointer(capsule, CAPSULE_CAPTURE_NAME);
 
   k4a_image_t image = k4a_capture_get_color_image(*capture_handle);
   if (image == NULL) {
     fprintf(stderr, "Color image missed");
-    return Py_BuildValue("K", iso_speed);
+    return Py_BuildValue("I", iso_speed);
   }
   iso_speed = k4a_image_get_iso_speed(image);
   k4a_image_release(image);
-  return Py_BuildValue("K", iso_speed);
+  return Py_BuildValue("I", iso_speed);
 }
 
 static PyObject *color_image_get_white_balance(PyObject *self, PyObject *args) {
@@ -1516,7 +1516,7 @@ static PyMethodDef Pyk4aMethods[] = {
     {"playback_get_next_imu_sample", playback_get_next_imu_sample, METH_VARARGS, "Get next imu sample from playback"},
     {"color_image_get_exposure_usec", color_image_get_exposure_usec, METH_VARARGS,
      "Get color image exposure in microseconds"},
-    {"color_image_get_iso_speed", color_image_get_iso_speed, METH_VARARGS, "Get ISO speed"},
+    {"color_image_get_iso_speed", color_image_get_iso_speed, METH_VARARGS, "Get color image ISO speed"},
     {"color_image_get_white_balance", color_image_get_white_balance, METH_VARARGS, "Get color image white balance"},
     {"record_create", record_create, METH_VARARGS, "Opens a new recording file for writing"},
     {"record_close", record_close, METH_VARARGS, "Opens a new recording file for writing"},

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyk4a
-version = 1.4.0
+version = 1.4.1
 description-file = README.md
 description = Python wrapper over Azure Kinect SDK
 long_description = file: README.md

--- a/tests/functional/test_capture.py
+++ b/tests/functional/test_capture.py
@@ -23,3 +23,4 @@ class TestCapture:
         assert np.array_equal(ir, color) is False
         assert capture.color_white_balance is not None
         assert capture.color_exposure_usec is not None
+        assert capture.color_iso_speed is not None


### PR DESCRIPTION
- Python Function called color_iso_speed since the iso "speed" (What Microsoft calls it) is currently only available for color images.
- Color iso speed property documentation is just copied from Microsoft's page
- This function must call Capture.color before requesting (like other color image functions)
- ISO speed is 0 when not available and raises "Cannot read iso from color_image" when 0 is returned.
- "Color image missed" when the image is not returned in pyk4a.cpp definition.
- Testing simply tests if capture.color_iso_speed is not None (initialized as none, 0 if error)
- Tested and works on live capture from the camera and not playback.