### PR TITLE
Fixing the context manager for playback objects

### DIFF
--- a/pyk4a/playback.py
+++ b/pyk4a/playback.py
@@ -168,7 +168,7 @@ class PyK4APlayback:
             thread_safe=self.thread_safe,
         )
 
-    def get_previouse_capture(self):
+    def get_previous_capture(self):
         self._validate_is_open()
         result, capture_handle = k4a_module.playback_get_previous_capture(self._handle, self.thread_safe)
         self._verify_stream_error(result)

--- a/pyk4a/playback.py
+++ b/pyk4a/playback.py
@@ -57,7 +57,7 @@ class PyK4APlayback:
         self.open()
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
     @property

--- a/pyk4a/playback.py
+++ b/pyk4a/playback.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from enum import IntEnum
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
@@ -167,6 +168,12 @@ class PyK4APlayback:
             color_format=self.configuration["color_format"],
             thread_safe=self.thread_safe,
         )
+
+    def get_previouse_capture(self):
+        warnings.warn(
+            "get_previouse_capture() deprecated, please use get_previous_capture() instead", DeprecationWarning
+        )
+        return self.get_previous_capture()
 
     def get_previous_capture(self):
         self._validate_is_open()

--- a/tests/functional/test_playback.py
+++ b/tests/functional/test_playback.py
@@ -72,14 +72,14 @@ class TestSeek:
         capture = playback.get_next_capture()
         assert capture.color is not None
         with pytest.raises(EOFError):
-            playback.get_previouse_capture()
+            playback.get_previous_capture()
 
     @staticmethod
     def test_seek_from_end(playback: PyK4APlayback):
         # TODO fetch capture/data and validate time
         playback.open()
         playback.seek(0, origin=SeekOrigin.END)
-        capture = playback.get_previouse_capture()
+        capture = playback.get_previous_capture()
         assert capture.color is not None
         with pytest.raises(EOFError):
             playback.get_next_capture()
@@ -107,10 +107,10 @@ class TestGetCapture:
         assert capture._calibration is not None  # Issue #81
 
     @staticmethod
-    def test_get_previouse_capture(playback: PyK4APlayback):
+    def test_get_previous_capture(playback: PyK4APlayback):
         playback.open()
         playback.seek(0, origin=SeekOrigin.END)
-        capture = playback.get_previouse_capture()
+        capture = playback.get_previous_capture()
         assert capture is not None
         assert capture.depth is not None
         assert capture.color is not None


### PR DESCRIPTION
As mentioned in #180 : the `__exit__()` method should be able to receive 4 arguments.
Also fixed a small typo in playback.py (and corresponding tests).