### PR TITLE
Added method for getting the extrinsic transformation parameters

### DIFF
--- a/pyk4a/calibration.py
+++ b/pyk4a/calibration.py
@@ -203,4 +203,7 @@ class Calibration:
         """
         params = k4a_module.calibration_get_extrinsics(self._calibration_handle, self.thread_safe, source_camera, target_camera)
 
-        return np.array(params[0]), np.array(params[1])
+        rotation = np.reshape(np.array(params[0]), [3, 3])
+        translation = np.reshape(np.array(params[1]), [1, 3]) / 1000 # Millimeter to meter conversion
+
+        return rotation, translation

--- a/pyk4a/calibration.py
+++ b/pyk4a/calibration.py
@@ -196,3 +196,11 @@ class Calibration:
             raise ValueError("Unknown camera calibration type")
 
         return np.array([params[4], params[5], params[13], params[12], *params[6:10]])
+
+    def get_extrinsic_parameters(self, source_camera: CalibrationType, target_camera: CalibrationType) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        The extrinsic parameters allow 3D coordinate conversions between depth camera, color camera, the IMU's gyroscope and accelerometer.
+        """
+        params = k4a_module.calibration_get_extrinsics(self._calibration_handle, self.thread_safe, source_camera, target_camera)
+
+        return np.array(params[0]), np.array(params[1])

--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -1107,6 +1107,29 @@ static PyObject *calibration_get_intrinsics(PyObject *self, PyObject *args) {
   return Py_BuildValue("N", intrinsics);
 }
 
+static PyObject *calibration_get_extrinsics(PyObject *self, PyObject *args) {
+  k4a_calibration_t *calibration_handle;
+  PyObject *capsule;
+  int thread_safe;
+  k4a_calibration_type_t source_camera;
+  k4a_calibration_type_t target_camera;
+  PyThreadState *thread_state;
+
+  PyArg_ParseTuple(args, "OpII", &capsule, &thread_safe, &source_camera, &target_camera);
+  calibration_handle = (k4a_calibration_t *)PyCapsule_GetPointer(capsule, CAPSULE_CALIBRATION_NAME);
+
+  thread_state = _gil_release(thread_safe);
+
+  k4a_calibration_extrinsics_t calib = calibration_handle->extrinsics[source_camera][target_camera];
+
+  _gil_restore(thread_state);
+
+  PyObject *rotation = _array_to_list(calib.rotation, 9);
+  PyObject *translation = _array_to_list(calib.translation, 3);
+
+  return Py_BuildValue("NN", rotation, translation);
+}
+
 static PyObject *playback_open(PyObject *self, PyObject *args) {
   int thread_safe;
   PyThreadState *thread_state;
@@ -1500,6 +1523,8 @@ static PyMethodDef Pyk4aMethods[] = {
      "Transform a 3D point of a source coordinate system into a 2D pixel coordinate of the target camera"},
     {"calibration_get_intrinsics", calibration_get_intrinsics, METH_VARARGS,
      "Gets intrinsic parameters from calibration"},
+    {"calibration_get_extrinsics", calibration_get_extrinsics, METH_VARARGS,
+     "Gets extrinsic parameters from calibration"},
     {"playback_open", playback_open, METH_VARARGS, "Open file for playback"},
     {"playback_close", playback_close, METH_VARARGS, "Close opened playback"},
     {"playback_get_recording_length_usec", playback_get_recording_length_usec, METH_VARARGS, "Return recording length"},


### PR DESCRIPTION
(Reopened with proper feature branch based on develop)

I added a simple method for retrieving the [extrinsic transformation parameters](https://microsoft.github.io/Azure-Kinect-Sensor-SDK/master/structk4a__calibration__t_a03f4b1600f8088739ffeea818a5df890.html#a03f4b1600f8088739ffeea818a5df890).

The method returns the rotation matrix and translation vector from a source to a target calibration type (for example color to depth).