### PR TITLE
Fixed python build wheel requirements error: Expected end or semicolon (after name and no valid version specifier)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
 packages = pyk4a
 install_requires =
     numpy
-    python_version >= "3.4"
 
 [options.package_data]
 pyk4a = py.typed


### PR DESCRIPTION
I get the following error when building with these versions:

- Python 3.9.13
- setuptools 67.0.0

> pkg_resources.extern.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after name and no valid version specifier)
          python_version >= "3.4"

![image](https://user-images.githubusercontent.com/97447968/215741374-a09cb97c-d758-437c-be4f-f69fc53924bd.png)

The problem seems to be a left-over "python_version" specifier from [this commit](https://github.com/etiennedub/pyk4a/commit/60a7cf0192c55ec5dce7eed6c0c49e4e1f7b6d95).