### PR TITLE
Fix setup.cfg metadata.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ classifiers =
 
 [options]
 packages = pyk4a
+python_requires = >= 3.4
 install_requires =
     numpy
-python_version >= 3.4
 
 [options.package_data]
 pyk4a = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 packages = pyk4a
 install_requires =
     numpy
-    python_version >= "3.4"
+python_version >= 3.4
 
 [options.package_data]
 pyk4a = py.typed


### PR DESCRIPTION
The 67.0.0 release of setuptools upgraded its vendored packaging to 23.0 and that release has improved, more strict version parsing code. That code errors out parsing `python_version >= "3.4"` from the `install_requires` metadata. Although that can be fixed by removing the quotes around the version, that metdata is in the wrong place. Fix this by specifying `python_requires` metdata correctly.

Fixes #194