### PR TITLE
Update python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup Python 3.7
+    - name: Setup Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Cache PyPI
       uses: actions/cache@v2
       with:
@@ -49,7 +49,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: true
     name: Test
     runs-on: ubuntu-18.04


### PR DESCRIPTION
- moved linter python version to 3.9
- deprecated python 3.6
- test package install on python 3.7 to 3.11 (currently supported versions from https://devguide.python.org/versions/)